### PR TITLE
Account Creation Defaults

### DIFF
--- a/View/Wzaccounts/create.ctp
+++ b/View/Wzaccounts/create.ctp
@@ -96,10 +96,10 @@ $(document).ready(function() {
 		'label' => __d('webzash', 'Database schema'),
 		'afterInput' => '<span class="help-block">' . __d('webzash', 'Note : Database schema is required for Postgres database connection. Leave it blank for MySQL connections.') . '</span>',
 	));
-	echo $this->Form->input('db_password', array('type' => 'password', 'label' => __d('webzash', 'Database password')));
 	echo $this->Form->input('db_host', array('label' => __d('webzash', 'Database host'), 'value' => 'localhost'));
 	echo $this->Form->input('db_port', array('label' => __d('webzash', 'Database port'), 'value' => '3306' ));
 	echo $this->Form->input('db_login', array('label' => __d('webzash', 'Database login'), 'value' => 'root'));
+	echo $this->Form->input('db_password', array('label' => __d('webzash', 'Database password')));
 	echo $this->Form->input('db_prefix', array(
 		'label' => __d('webzash', 'Database prefix'),
 		'value' => 'wz_',

--- a/View/Wzaccounts/create.ctp
+++ b/View/Wzaccounts/create.ctp
@@ -96,12 +96,13 @@ $(document).ready(function() {
 		'label' => __d('webzash', 'Database schema'),
 		'afterInput' => '<span class="help-block">' . __d('webzash', 'Note : Database schema is required for Postgres database connection. Leave it blank for MySQL connections.') . '</span>',
 	));
-	echo $this->Form->input('db_host', array('label' => __d('webzash', 'Database host')));
-	echo $this->Form->input('db_port', array('label' => __d('webzash', 'Database port')));
-	echo $this->Form->input('db_login', array('label' => __d('webzash', 'Database login')));
 	echo $this->Form->input('db_password', array('type' => 'password', 'label' => __d('webzash', 'Database password')));
+	echo $this->Form->input('db_host', array('label' => __d('webzash', 'Database host'), 'value' => 'localhost'));
+	echo $this->Form->input('db_port', array('label' => __d('webzash', 'Database port'), 'value' => '3306' ));
+	echo $this->Form->input('db_login', array('label' => __d('webzash', 'Database login'), 'value' => 'root'));
 	echo $this->Form->input('db_prefix', array(
 		'label' => __d('webzash', 'Database prefix'),
+		'value' => 'wz_',
 		'afterInput' => '<span class="help-block">' . __d('webzash', 'Note : Database table prefix to use (optional). All tables for this account will be created with this prefix, useful if you have only one database available and want to use multiple accounts.') . '</span>',
 	));
 	echo $this->Form->input('db_persistent', array('type' => 'checkbox', 'label' => __d('webzash', 'Use persistent connection'), 'class' => 'checkbox'));


### PR DESCRIPTION
Adds defaults to the account creation process. This helps because for some users these options will actually work. For other users, by filling in sample data it will identify which fields are which more quickly.

Also, given how infrequently the database password field will be used (only when you create the account), it is not necessary that the field be typed as a `password` field. The obfuscation is problematic for something like a server password which is usually fairly complex and random.